### PR TITLE
Apply matrix-based copy-paste within the grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Data fetching is abstracted through a `DataSource` interface, supporting both:
 - **Column Filtering**: Built-in filter row with debounced input
 - **Cell Editing**: Double-click or press Enter to edit, with custom editor support
 - **Fill Handle**: Excel-like drag-to-fill for editable cells
-- **Keyboard Navigation**: Arrow keys, Tab, Enter, Escape, Ctrl+A, Ctrl+C
+- **Keyboard Navigation**: Arrow keys, Tab, Enter, Escape, Ctrl+A, Ctrl+C, Ctrl+V
 - **Custom Renderers**: Registry-based cell, edit, and header renderers
 - **Dark Mode**: Built-in dark theme support
 - **TypeScript**: Full type safety with exported types

--- a/packages/angular/src/lib/gp-grid.component.ts
+++ b/packages/angular/src/lib/gp-grid.component.ts
@@ -252,6 +252,16 @@ export class GpGridComponent implements OnInit, AfterViewInit, OnDestroy {
     if (result.scrollToCell) this.bindings.scrollToRow(result.scrollToCell.row);
   }
 
+  protected onPaste(event: ClipboardEvent): void {
+    const editing = this.vm.editingCell();
+    const handled = this.bindings.input.pasteText(
+      event.clipboardData?.getData('text/plain') ?? '',
+      editing === null ? null : { row: editing.row, col: editing.col },
+      this.vm.filterPopup() !== null,
+    );
+    if (handled) event.preventDefault();
+  }
+
   protected onResizePointerDown(evt: ResizePointerDownEvent): void {
     if (this.bindings.input.resizePointerDown(evt.colIndex, evt.colWidth, evt.event)) {
       evt.event.preventDefault();

--- a/packages/angular/src/lib/gp-grid.template.ts
+++ b/packages/angular/src/lib/gp-grid.template.ts
@@ -4,6 +4,7 @@ export const GP_GRID_TEMPLATE = `
       style="width: 100%; height: 100%; display: flex; flex-direction: column; position: relative; outline: none;"
       tabindex="0"
       (keydown)="onKeyDown($event)"
+      (paste)="onPaste($event)"
       (wheel)="onWheel($event)"
     >
       <gp-grid-header

--- a/packages/core/src/adapter/input-event-adapter.ts
+++ b/packages/core/src/adapter/input-event-adapter.ts
@@ -193,6 +193,18 @@ export class InputEventAdapter<TData = unknown> {
     );
   }
 
+  pasteText(
+    text: string,
+    editingCell: { row: number; col: number } | null,
+    filterPopupOpen: boolean,
+  ): boolean {
+    const core = this.deps.getCore();
+    if (core === null) return false;
+    if (editingCell !== null) return false;
+    if (filterPopupOpen) return false;
+    return core.pasteClipboardText(text);
+  }
+
   private dispatchCellDragStart(
     startDrag: InputResult["startDrag"],
     event: PointerEvent,

--- a/packages/core/src/data-source/client-data-source.ts
+++ b/packages/core/src/data-source/client-data-source.ts
@@ -25,7 +25,10 @@ const WORKER_THRESHOLD = 200000;
 /**
  * Default field value accessor supporting dot-notation for nested properties
  */
-export function defaultGetFieldValue<TData>(row: TData, field: string): CellValue {
+export function defaultGetFieldValue<TData>(
+  row: TData,
+  field: string,
+): CellValue {
   const parts = field.split(".");
   let value: unknown = row;
 
@@ -95,9 +98,9 @@ export function createClientDataSource<TData = unknown>(
       // Apply filters (always sync - filtering is fast)
       if (request.filter && Object.keys(request.filter).length > 0) {
         const formatterLookup =
-          request.valueFormatters != null
-            ? (field: string) => request.valueFormatters?.[field]
-            : getValueFormatter;
+          request.valueFormatters === null
+            ? getValueFormatter
+            : (field: string) => request.valueFormatters?.[field];
         processedData = applyFilters(
           processedData,
           request.filter,
@@ -114,7 +117,12 @@ export function createClientDataSource<TData = unknown>(
           processedData.length >= WORKER_THRESHOLD;
 
         processedData = canUseWorkerSort
-          ? await performWorkerSort(processedData, request.sort, sortManager, getFieldValue)
+          ? await performWorkerSort(
+              processedData,
+              request.sort,
+              sortManager,
+              getFieldValue,
+            )
           : applySort(processedData, request.sort, getFieldValue);
       }
 

--- a/packages/core/src/data-source/mutable-data-source.ts
+++ b/packages/core/src/data-source/mutable-data-source.ts
@@ -8,10 +8,7 @@ import type {
   CellValue,
 } from "../types";
 import { IndexedDataStore } from "../indexed-data-store";
-import {
-  TransactionManager,
-  type TransactionResult,
-} from "../managers";
+import { TransactionManager, type TransactionResult } from "../managers";
 import { ParallelSortManager, type ParallelSortOptions } from "../sorting";
 import { applySort } from "../indexed-data-store/sorting";
 import { defaultGetFieldValue } from "./client-data-source";
@@ -108,11 +105,14 @@ export function createMutableClientDataSource<TData = unknown>(
   } = options;
 
   // Create the indexed data store
-  const store = new IndexedDataStore({
-    getRowId,
-    getFieldValue: getFieldValue ?? defaultGetFieldValue,
-    getValueFormatter,
-  }, data);
+  const store = new IndexedDataStore(
+    {
+      getRowId,
+      getFieldValue: getFieldValue ?? defaultGetFieldValue,
+      getValueFormatter,
+    },
+    data,
+  );
 
   // Subscribers for data change notifications
   const subscribers = new Set<DataChangeListener>();
@@ -123,7 +123,9 @@ export function createMutableClientDataSource<TData = unknown>(
 
   // Create parallel sort manager only if both useWorker is enabled and parallelSort is not disabled
   const sortManager =
-    useWorker && parallelSort !== false ? new ParallelSortManager(parallelSort) : null;
+    useWorker && parallelSort !== false
+      ? new ParallelSortManager(parallelSort)
+      : null;
 
   // Create the transaction manager
   const transactionManager = new TransactionManager<TData>({
@@ -162,9 +164,9 @@ export function createMutableClientDataSource<TData = unknown>(
       // Apply filters (always sync - filtering is fast)
       if (request.filter && Object.keys(request.filter).length > 0) {
         const formatterLookup =
-          request.valueFormatters != null
-            ? (field: string) => request.valueFormatters?.[field]
-            : getValueFormatter;
+          request.valueFormatters === null
+            ? getValueFormatter
+            : (field: string) => request.valueFormatters?.[field];
         processedData = applyFilters(
           processedData,
           request.filter,
@@ -183,7 +185,12 @@ export function createMutableClientDataSource<TData = unknown>(
         if (canUseWorkerSort) {
           emit({ type: "DATA_LOADING" });
           try {
-            processedData = await performWorkerSort(processedData, request.sort, sortManager, fieldAccessor);
+            processedData = await performWorkerSort(
+              processedData,
+              request.sort,
+              sortManager,
+              fieldAccessor,
+            );
           } finally {
             emit({ type: "DATA_LOADED", totalRows: processedData.length });
           }

--- a/packages/core/src/grid-core-managers.ts
+++ b/packages/core/src/grid-core-managers.ts
@@ -80,6 +80,7 @@ export const buildGridManagers = <TData>(
     getCellValue: deps.getCellValue,
     getRowData: (row) => deps.getCachedRows().get(row),
     getColumn: (col) => deps.getColumns()[col],
+    setCellValue: deps.setCellValue,
   });
   selection.onInstruction((instruction) => {
     batcher.emit(instruction);

--- a/packages/core/src/grid-core.ts
+++ b/packages/core/src/grid-core.ts
@@ -313,6 +313,17 @@ export class GridCore<TData = unknown> {
     this.editManager.cancel();
   }
 
+  pasteClipboardText(text: string): boolean {
+    if (this.editManager.getState()) return false;
+
+    const result = this.selection.pasteClipboardText(text);
+    if (result.changedCells.length > 0) {
+      this.refreshSlotData();
+    }
+
+    return result.handled;
+  }
+
   getEditState(): EditState | null {
     return this.editManager.getState();
   }

--- a/packages/core/src/selection.ts
+++ b/packages/core/src/selection.ts
@@ -8,6 +8,13 @@ import type {
   ColumnDefinition,
 } from "./types";
 import { createInstructionEmitter, normalizeRange, formatCellValue } from "./utils";
+import {
+  coerceClipboardValue,
+  normalizeClipboardText,
+  parseClipboardText,
+  type ClipboardCell,
+  type ClipboardMatrix,
+} from "./utils/clipboard-helpers";
 
 export type Direction = "up" | "down" | "left" | "right";
 
@@ -17,6 +24,17 @@ export interface SelectionManagerOptions {
   getCellValue: (row: number, col: number) => CellValue;
   getRowData: (row: number) => unknown;
   getColumn: (col: number) => ColumnDefinition | undefined;
+  setCellValue: (row: number, col: number, value: CellValue) => void;
+}
+
+export interface PasteResult {
+  handled: boolean;
+  changedCells: Array<{ row: number; col: number; value: CellValue }>;
+}
+
+interface ClipboardSnapshot {
+  text: string;
+  cells: ClipboardMatrix;
 }
 
 /**
@@ -32,6 +50,7 @@ export class SelectionManager {
 
   private readonly options: SelectionManagerOptions;
   private readonly emitter = createInstructionEmitter();
+  private clipboardSnapshot: ClipboardSnapshot | null = null;
 
   // Public API delegates to emitter
   onInstruction = this.emitter.onInstruction;
@@ -253,34 +272,42 @@ export class SelectionManager {
    * Copy the selected data to the clipboard (Ctrl+C).
    */
   async copySelectionToClipboard(): Promise<void> {
+    const effectiveRange = this.getEffectiveRange();
+    if (effectiveRange === null) return;
+
+    const snapshot = this.createClipboardSnapshot(effectiveRange);
+    if (snapshot.cells.length === 0) return;
+
+    this.clipboardSnapshot = snapshot;
+
     // Guard for SSR - clipboard APIs not available in Node.js
     if (typeof navigator === "undefined" || typeof document === "undefined") {
       return;
     }
 
+    await navigator.clipboard.writeText(snapshot.text);
+  }
+
+  /**
+   * Paste text data into the active cell or selected target range.
+   */
+  pasteClipboardText(text: string): PasteResult {
     const effectiveRange = this.getEffectiveRange();
-    if (effectiveRange === null) return;
+    if (effectiveRange === null) {
+      return { handled: false, changedCells: [] };
+    }
 
-    const data = this.getSelectedData();
-    if (data.length === 0) return;
+    const sourceCells = this.getPasteSourceCells(text);
+    if (sourceCells.length === 0) {
+      return { handled: false, changedCells: [] };
+    }
 
-    const { minCol } = normalizeRange(effectiveRange);
-
-    // Convert to tab-separated values (Excel-compatible)
-    const tsv = data
-      .map((row) =>
-        row
-          .map((cell, colOffset) =>
-            formatCellValue(
-              cell,
-              this.options.getColumn(minCol + colOffset)?.valueFormatter,
-            ),
-          )
-          .join("\t"),
-      )
-      .join("\n");
-
-    await navigator.clipboard.writeText(tsv);
+    const changedCells = this.applyPasteSource(
+      sourceCells,
+      effectiveRange,
+      this.state.range !== null,
+    );
+    return { handled: true, changedCells };
   }
 
   // ===========================================================================
@@ -298,6 +325,7 @@ export class SelectionManager {
       anchor: null,
       selectionMode: false,
     };
+    this.clipboardSnapshot = null;
   }
 
   // ===========================================================================
@@ -328,5 +356,122 @@ export class SelectionManager {
 
     return null;
   }
-}
 
+  private createClipboardSnapshot(range: CellRange): ClipboardSnapshot {
+    const { minRow, maxRow, minCol, maxCol } = normalizeRange(range);
+    const cells: ClipboardMatrix = [];
+
+    for (let row = minRow; row <= maxRow; row++) {
+      const rowCells: ClipboardCell[] = [];
+      for (let col = minCol; col <= maxCol; col++) {
+        const value = this.options.getCellValue(row, col);
+        const text = formatCellValue(
+          value,
+          this.options.getColumn(col)?.valueFormatter,
+        );
+        rowCells.push({ value, text });
+      }
+      cells.push(rowCells);
+    }
+
+    return {
+      cells,
+      text: cells.map((row) => row.map((cell) => cell.text).join("\t")).join("\n"),
+    };
+  }
+
+  private getPasteSourceCells(text: string): ClipboardMatrix {
+    const snapshot = this.clipboardSnapshot;
+    if (snapshot && normalizeClipboardText(snapshot.text) === normalizeClipboardText(text)) {
+      return snapshot.cells;
+    }
+
+    return parseClipboardText(text);
+  }
+
+  private applyPasteSource(
+    sourceCells: ClipboardMatrix,
+    targetRange: CellRange,
+    targetIsSelection: boolean,
+  ): Array<{ row: number; col: number; value: CellValue }> {
+    const changedCells: Array<{ row: number; col: number; value: CellValue }> = [];
+    const { minRow, maxRow, minCol, maxCol } = normalizeRange(targetRange);
+    const isSingleSourceCell = this.isSingleSourceCell(sourceCells);
+
+    const sourceMaxRow = isSingleSourceCell
+      ? maxRow
+      : minRow + sourceCells.length - 1;
+    const sourceMaxCol = isSingleSourceCell
+      ? maxCol
+      : minCol + this.getMaxSourceColumnCount(sourceCells) - 1;
+    const targetMaxRow = targetIsSelection
+      ? Math.min(sourceMaxRow, maxRow)
+      : sourceMaxRow;
+    const targetMaxCol = targetIsSelection
+      ? Math.min(sourceMaxCol, maxCol)
+      : sourceMaxCol;
+
+    const rowCount = this.options.getRowCount();
+    const colCount = this.options.getColumnCount();
+    const boundedMaxRow = Math.min(targetMaxRow, rowCount - 1);
+    const boundedMaxCol = Math.min(targetMaxCol, colCount - 1);
+
+    for (let row = minRow; row <= boundedMaxRow; row++) {
+      for (let col = minCol; col <= boundedMaxCol; col++) {
+        const sourceCell = this.getSourceCellForTarget(
+          sourceCells,
+          row - minRow,
+          col - minCol,
+          isSingleSourceCell,
+        );
+        if (sourceCell) {
+          this.applyPasteCell(row, col, sourceCell, changedCells);
+        }
+      }
+    }
+
+    return changedCells;
+  }
+
+  private applyPasteCell(
+    row: number,
+    col: number,
+    sourceCell: ClipboardCell,
+    changedCells: Array<{ row: number; col: number; value: CellValue }>,
+  ): void {
+    const column = this.options.getColumn(col);
+    if (column === undefined) return;
+    if (column.hidden === true) return;
+    if (column.editable !== true) return;
+
+    const coerced = coerceClipboardValue(sourceCell, column);
+    if (coerced.ok === false) return;
+
+    this.options.setCellValue(row, col, coerced.value);
+    changedCells.push({ row, col, value: coerced.value });
+  }
+
+  private getSourceCellForTarget(
+    sourceCells: ClipboardMatrix,
+    rowOffset: number,
+    colOffset: number,
+    isSingleSourceCell: boolean,
+  ): ClipboardCell | null {
+    if (isSingleSourceCell) {
+      return sourceCells[0]?.[0] ?? null;
+    }
+
+    return sourceCells[rowOffset]?.[colOffset] ?? null;
+  }
+
+  private isSingleSourceCell(sourceCells: ClipboardMatrix): boolean {
+    return sourceCells.length === 1 && sourceCells[0]?.length === 1;
+  }
+
+  private getMaxSourceColumnCount(sourceCells: ClipboardMatrix): number {
+    return sourceCells.reduce(
+      (maxCount, row) => Math.max(maxCount, row.length),
+      0,
+    );
+  }
+}

--- a/packages/core/src/types/basic.ts
+++ b/packages/core/src/types/basic.ts
@@ -72,7 +72,7 @@ export interface FillHandleState {
   targetCol: number;
 }
 
-/** Event emitted when a cell value is changed via editing or fill drag */
+/** Event emitted when a cell value is changed via editing, fill drag, or paste */
 export interface CellValueChangedEvent<TData = unknown> {
   /** Stable row ID (from getRowId) */
   rowId: RowId;

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -26,7 +26,7 @@ export interface GridCoreOptions<TData = unknown> {
   getRowId?: (row: TData) => RowId;
   /** Row/column/cell highlighting configuration */
   highlighting?: HighlightingOptions<TData>;
-  /** Called when a cell value is changed via editing or fill drag. Requires getRowId. */
+  /** Called when a cell value is changed via editing, fill drag, or paste. Requires getRowId. */
   onCellValueChanged?: (event: CellValueChangedEvent<TData>) => void;
   /** Whether clicking and dragging any cell in a row drags the entire row instead of starting selection. Default: false */
   rowDragEntireRow?: boolean;

--- a/packages/core/src/utils/clipboard-helpers.ts
+++ b/packages/core/src/utils/clipboard-helpers.ts
@@ -1,0 +1,146 @@
+import type { CellValue, ColumnDefinition } from "../types";
+
+export interface ClipboardCell {
+  value: CellValue;
+  text: string;
+}
+
+export type ClipboardMatrix = ClipboardCell[][];
+
+export type CoerceClipboardValueResult =
+  | { ok: true; value: CellValue }
+  | { ok: false };
+
+export const normalizeClipboardText = (text: string): string =>
+  text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+
+export const parseClipboardText = (text: string): ClipboardMatrix => {
+  const normalized = normalizeClipboardText(text);
+  const lines = normalized.split("\n");
+
+  if (lines.length > 1 && lines.at(-1) === "") {
+    lines.pop();
+  }
+
+  return lines.map((line) =>
+    line.split("\t").map((cellText) => ({
+      value: cellText,
+      text: cellText,
+    })),
+  );
+};
+
+export const coerceClipboardValue = (
+  cell: ClipboardCell,
+  column: ColumnDefinition,
+): CoerceClipboardValueResult => {
+  if (cell.value === null) return { ok: true, value: null };
+
+  const text = cell.text;
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return coerceBlankValue(column);
+
+  switch (column.cellDataType) {
+    case "text":
+      return { ok: true, value: text };
+    case "number":
+      return coerceNumber(cell.value, trimmed);
+    case "boolean":
+      return coerceBoolean(cell.value, trimmed);
+    case "date":
+    case "dateTime":
+      return coerceDate(cell.value, trimmed);
+    case "dateString":
+    case "dateTimeString":
+      return coerceDateString(trimmed, text);
+    case "object":
+      return coerceObject(cell.value, trimmed);
+  }
+};
+
+const coerceBlankValue = (
+  column: ColumnDefinition,
+): CoerceClipboardValueResult => {
+  if (column.cellDataType === "text") return { ok: true, value: "" };
+  return { ok: true, value: null };
+};
+
+const coerceNumber = (
+  value: CellValue,
+  trimmed: string,
+): CoerceClipboardValueResult => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return { ok: true, value };
+  }
+
+  const numericValue = Number(trimmed);
+  if (Number.isFinite(numericValue)) {
+    return { ok: true, value: numericValue };
+  }
+
+  return { ok: false };
+};
+
+const coerceBoolean = (
+  value: CellValue,
+  trimmed: string,
+): CoerceClipboardValueResult => {
+  if (typeof value === "boolean") return { ok: true, value };
+
+  const normalized = trimmed.toLowerCase();
+  if (normalized === "true") return { ok: true, value: true };
+  if (normalized === "false") return { ok: true, value: false };
+
+  return { ok: false };
+};
+
+const coerceDate = (
+  value: CellValue,
+  trimmed: string,
+): CoerceClipboardValueResult => {
+  if (value instanceof Date && isValidDate(value)) {
+    return { ok: true, value };
+  }
+
+  const parsed = new Date(trimmed);
+  if (isValidDate(parsed)) {
+    return { ok: true, value: parsed };
+  }
+
+  return { ok: false };
+};
+
+const coerceDateString = (
+  trimmed: string,
+  originalText: string,
+): CoerceClipboardValueResult => {
+  const parsed = new Date(trimmed);
+  if (isValidDate(parsed)) {
+    return { ok: true, value: originalText };
+  }
+
+  return { ok: false };
+};
+
+const coerceObject = (
+  value: CellValue,
+  trimmed: string,
+): CoerceClipboardValueResult => {
+  if (value !== null && typeof value === "object" && !(value instanceof Date)) {
+    return { ok: true, value };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed !== null && typeof parsed === "object") {
+      return { ok: true, value: parsed };
+    }
+  } catch {
+    return { ok: false };
+  }
+
+  return { ok: false };
+};
+
+const isValidDate = (value: Date): boolean =>
+  Number.isFinite(value.getTime());

--- a/packages/core/src/utils/clipboard-helpers.ts
+++ b/packages/core/src/utils/clipboard-helpers.ts
@@ -12,7 +12,7 @@ export type CoerceClipboardValueResult =
   | { ok: false };
 
 export const normalizeClipboardText = (text: string): string =>
-  text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  text.replaceAll(/\r\n/g, "\n").replaceAll(/\r/g, "\n");
 
 export const parseClipboardText = (text: string): ClipboardMatrix => {
   const normalized = normalizeClipboardText(text);
@@ -142,5 +142,4 @@ const coerceObject = (
   return { ok: false };
 };
 
-const isValidDate = (value: Date): boolean =>
-  Number.isFinite(value.getTime());
+const isValidDate = (value: Date): boolean => Number.isFinite(value.getTime());

--- a/packages/core/src/utils/clipboard-helpers.ts
+++ b/packages/core/src/utils/clipboard-helpers.ts
@@ -12,7 +12,7 @@ export type CoerceClipboardValueResult =
   | { ok: false };
 
 export const normalizeClipboardText = (text: string): string =>
-  text.replaceAll(/\r\n/g, "\n").replaceAll(/\r/g, "\n");
+  text.replaceAll("\r\n", "\n").replaceAll("\r", "\n");
 
 export const parseClipboardText = (text: string): ClipboardMatrix => {
   const normalized = normalizeClipboardText(text);

--- a/packages/core/tests/auto-scroll.test.ts
+++ b/packages/core/tests/auto-scroll.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AutoScrollDriver } from "../src/adapter/auto-scroll";
+
+describe("AutoScrollDriver", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("scrolls the body and replays the last pointer event on each tick", () => {
+    const body = document.createElement("div");
+    const pointerEvent = new PointerEvent("pointermove");
+    const onTick = vi.fn();
+    const driver = new AutoScrollDriver(() => body, onTick);
+
+    driver.recordPointer(pointerEvent);
+    driver.start(3, 4);
+    vi.advanceTimersByTime(16);
+
+    expect(body.scrollLeft).toBe(3);
+    expect(body.scrollTop).toBe(4);
+    expect(onTick).toHaveBeenCalledWith(pointerEvent);
+
+    driver.stop();
+  });
+
+  it("does not replay a pointer event after it is cleared", () => {
+    const body = document.createElement("div");
+    const onTick = vi.fn();
+    const driver = new AutoScrollDriver(() => body, onTick);
+
+    driver.recordPointer(new PointerEvent("pointermove"));
+    driver.clearPointer();
+    driver.start(1, 2);
+    vi.advanceTimersByTime(16);
+
+    expect(body.scrollLeft).toBe(1);
+    expect(body.scrollTop).toBe(2);
+    expect(onTick).not.toHaveBeenCalled();
+
+    driver.stop();
+  });
+
+  it("skips scrolling when there is no body element", () => {
+    const onTick = vi.fn();
+    const driver = new AutoScrollDriver(() => null, onTick);
+
+    driver.recordPointer(new PointerEvent("pointermove"));
+    driver.start(1, 1);
+    vi.advanceTimersByTime(16);
+
+    expect(onTick).not.toHaveBeenCalled();
+
+    driver.stop();
+  });
+});

--- a/packages/core/tests/grid-core.test.ts
+++ b/packages/core/tests/grid-core.test.ts
@@ -529,6 +529,36 @@ describe("GridCore", () => {
     });
   });
 
+  describe("clipboard paste", () => {
+    it("pastes compatible values and emits cell value changes", async () => {
+      const onCellValueChanged = vi.fn();
+      const pasteGrid = new GridCore<TestRow>({
+        columns,
+        dataSource: createClientDataSource(JSON.parse(JSON.stringify(sampleData)) as TestRow[]),
+        rowHeight: 32,
+        getRowId: (row) => row.id,
+        onCellValueChanged,
+      });
+
+      await pasteGrid.initialize();
+      pasteGrid.selection.startSelection({ row: 0, col: 2 });
+
+      const handled = pasteGrid.pasteClipboardText("44");
+
+      expect(handled).toBe(true);
+      expect(pasteGrid.getCellValue(0, 2)).toBe(44);
+      expect(onCellValueChanged).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rowId: 1,
+          colIndex: 2,
+          field: "age",
+          oldValue: 30,
+          newValue: 44,
+        }),
+      );
+    });
+  });
+
   describe("public accessors", () => {
     it("should return columns", async () => {
       await grid.initialize();

--- a/packages/core/tests/pending-row-drag.test.ts
+++ b/packages/core/tests/pending-row-drag.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GridCore } from "../src/grid-core";
+import { PendingRowDragController } from "../src/adapter/pending-row-drag";
+import type { DragState } from "../src/types";
+
+const dragState: DragState = {
+  isDragging: true,
+  dragType: "row-drag",
+  fillSourceRange: null,
+  fillTarget: null,
+  columnResize: null,
+  columnMove: null,
+  rowDrag: {
+    sourceRowIndex: 1,
+    currentX: 10,
+    currentY: 20,
+    dropTargetIndex: null,
+    dropIndicatorY: 0,
+  },
+};
+
+const createCore = (
+  confirmPendingRowDrag = vi.fn(() => true),
+): GridCore<unknown> => {
+  const core = {
+    input: {
+      cancelPendingRowDrag: vi.fn(),
+      confirmPendingRowDrag,
+      getDragState: vi.fn(() => dragState),
+    },
+  };
+  return core as unknown as GridCore<unknown>;
+};
+
+const startFromElement = (
+  controller: PendingRowDragController,
+  target: HTMLElement,
+  eventInit: PointerEventInit = {},
+): void => {
+  target.addEventListener(
+    "pointerdown",
+    (event) => controller.start(event),
+    { once: true },
+  );
+  target.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      clientX: 10,
+      clientY: 20,
+      pointerId: 5,
+      ...eventInit,
+    }),
+  );
+};
+
+describe("PendingRowDragController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("confirms pending row drag after the hold delay", () => {
+    const container = document.createElement("div");
+    container.style.overflow = "auto";
+    const target = document.createElement("div");
+    const setPointerCapture = vi.fn<(pointerId: number) => void>();
+    Object.defineProperty(target, "setPointerCapture", {
+      configurable: true,
+      value: setPointerCapture,
+    });
+    const onDragConfirmed = vi.fn();
+    const core = createCore();
+    const controller = new PendingRowDragController({
+      getCore: () => core,
+      getContainer: () => container,
+      isBrowser: true,
+      onDragConfirmed,
+    });
+
+    startFromElement(controller, target);
+    vi.advanceTimersByTime(300);
+
+    expect(core.input.confirmPendingRowDrag).toHaveBeenCalled();
+    expect(container.style.overflow).toBe("hidden");
+    expect(setPointerCapture).toHaveBeenCalledWith(5);
+    expect(onDragConfirmed).toHaveBeenCalledWith(dragState);
+
+    controller.releaseLocks();
+
+    expect(container.style.overflow).toBe("auto");
+  });
+
+  it("cancels pending row drag when pointer movement exceeds the threshold", () => {
+    const core = createCore();
+    const controller = new PendingRowDragController({
+      getCore: () => core,
+      getContainer: () => document.createElement("div"),
+      isBrowser: true,
+      onDragConfirmed: vi.fn(),
+    });
+
+    startFromElement(controller, document.createElement("div"));
+    document.dispatchEvent(
+      new PointerEvent("pointermove", {
+        clientX: 25,
+        clientY: 20,
+      }),
+    );
+    vi.advanceTimersByTime(300);
+
+    expect(core.input.cancelPendingRowDrag).toHaveBeenCalled();
+    expect(core.input.confirmPendingRowDrag).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending row drag when pointer is released before the hold delay", () => {
+    const core = createCore();
+    const controller = new PendingRowDragController({
+      getCore: () => core,
+      getContainer: () => document.createElement("div"),
+      isBrowser: true,
+      onDragConfirmed: vi.fn(),
+    });
+
+    startFromElement(controller, document.createElement("div"));
+    document.dispatchEvent(new PointerEvent("pointerup"));
+    vi.advanceTimersByTime(300);
+
+    expect(core.input.cancelPendingRowDrag).toHaveBeenCalled();
+    expect(core.input.confirmPendingRowDrag).not.toHaveBeenCalled();
+  });
+
+  it("does not release container locks outside the browser", () => {
+    const container = document.createElement("div");
+    container.style.overflow = "hidden";
+    const controller = new PendingRowDragController({
+      getCore: () => null,
+      getContainer: () => container,
+      isBrowser: false,
+      onDragConfirmed: vi.fn(),
+    });
+
+    controller.releaseLocks();
+
+    expect(container.style.overflow).toBe("hidden");
+  });
+});

--- a/packages/core/tests/pointer-event.test.ts
+++ b/packages/core/tests/pointer-event.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { toPointerEventData } from "../src/adapter/pointer-event";
+
+describe("toPointerEventData", () => {
+  it("converts a DOM PointerEvent to core pointer event data", () => {
+    const event = new PointerEvent("pointerdown", {
+      clientX: 12,
+      clientY: 34,
+      button: 1,
+      shiftKey: true,
+      ctrlKey: true,
+      metaKey: true,
+      pointerId: 9,
+      pointerType: "pen",
+    });
+
+    expect(toPointerEventData(event)).toEqual({
+      clientX: 12,
+      clientY: 34,
+      button: 1,
+      shiftKey: true,
+      ctrlKey: true,
+      metaKey: true,
+      pointerId: 9,
+      pointerType: "pen",
+    });
+  });
+});

--- a/packages/core/tests/selection.test.ts
+++ b/packages/core/tests/selection.test.ts
@@ -2,12 +2,12 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SelectionManager, type SelectionManagerOptions } from "../src/selection";
-import type { GridInstruction } from "../src/types";
+import type { CellValue, ColumnDefinition, GridInstruction } from "../src/types";
 
 function createMockOptions(
   rowCount = 10,
   colCount = 5
-): SelectionManagerOptions {
+): SelectionManagerOptions & { getData: () => Record<string, unknown>[][] } {
   const data: Record<string, unknown>[][] = [];
   for (let r = 0; r < rowCount; r++) {
     const row: Record<string, unknown>[] = [];
@@ -27,6 +27,13 @@ function createMockOptions(
       cellDataType: "text" as const,
       width: 100,
     }),
+    setCellValue: (row, col, value) => {
+      const rowData = data[row];
+      if (rowData) {
+        rowData[col] = { value };
+      }
+    },
+    getData: () => data,
   };
 }
 
@@ -58,6 +65,36 @@ const withFormattedColumn = (
 
     return column;
   },
+});
+
+const createPasteOptions = (
+  data: CellValue[][],
+  columns: ColumnDefinition[],
+): SelectionManagerOptions & { getData: () => CellValue[][] } => ({
+  getRowCount: () => data.length,
+  getColumnCount: () => columns.length,
+  getCellValue: (row, col) => data[row]?.[col] ?? null,
+  getRowData: (row) => data[row] ?? undefined,
+  getColumn: (col) => columns[col],
+  setCellValue: (row, col, value) => {
+    const rowData = data[row];
+    if (rowData) {
+      rowData[col] = value;
+    }
+  },
+  getData: () => data,
+});
+
+const editableColumn = (
+  field: string,
+  cellDataType: ColumnDefinition["cellDataType"],
+  extra: Partial<ColumnDefinition> = {},
+): ColumnDefinition => ({
+  field,
+  cellDataType,
+  width: 100,
+  editable: true,
+  ...extra,
 });
 
 describe("SelectionManager", () => {
@@ -457,6 +494,202 @@ describe("SelectionManager", () => {
       await manager.copySelectionToClipboard();
 
       expect(writeText).toHaveBeenCalledWith("R0C0\t[R0C1]\nR1C0\t[R1C1]");
+    });
+  });
+
+  describe("pasteClipboardText", () => {
+    it("fills a selected target range when the copied source is one cell", async () => {
+      const writeText = createClipboardWriteMock();
+      const pasteOptions = createPasteOptions(
+        [
+          [7, 0],
+          [0, 0],
+          [0, 0],
+        ],
+        [
+          editableColumn("a", "number"),
+          editableColumn("b", "number"),
+        ],
+      );
+      manager = new SelectionManager(pasteOptions);
+
+      manager.startSelection({ row: 0, col: 0 });
+      await manager.copySelectionToClipboard();
+      manager.startSelection({ row: 1, col: 0 });
+      manager.startSelection({ row: 2, col: 1 }, { shift: true });
+
+      const result = manager.pasteClipboardText("7");
+
+      expect(writeText).toHaveBeenCalledWith("7");
+      expect(result.handled).toBe(true);
+      expect(result.changedCells).toHaveLength(4);
+      expect(pasteOptions.getData()).toEqual([
+        [7, 0],
+        [7, 7],
+        [7, 7],
+      ]);
+    });
+
+    it("expands copied vertical cells from a single target cell", async () => {
+      createClipboardWriteMock();
+      const pasteOptions = createPasteOptions(
+        [
+          ["A", null],
+          ["B", null],
+          ["C", null],
+          ["D", null],
+        ],
+        [
+          editableColumn("source", "text"),
+          editableColumn("target", "text"),
+        ],
+      );
+      manager = new SelectionManager(pasteOptions);
+
+      manager.startSelection({ row: 0, col: 0 });
+      manager.startSelection({ row: 2, col: 0 }, { shift: true });
+      await manager.copySelectionToClipboard();
+      manager.startSelection({ row: 1, col: 1 });
+
+      const result = manager.pasteClipboardText("A\nB\nC");
+
+      expect(result.handled).toBe(true);
+      expect(result.changedCells).toEqual([
+        { row: 1, col: 1, value: "A" },
+        { row: 2, col: 1, value: "B" },
+        { row: 3, col: 1, value: "C" },
+      ]);
+      expect(pasteOptions.getData()).toEqual([
+        ["A", null],
+        ["B", "A"],
+        ["C", "B"],
+        ["D", "C"],
+      ]);
+    });
+
+    it("parses primitive and object values by target column type", () => {
+      const pasteOptions = createPasteOptions(
+        [[null, null, null, null, null]],
+        [
+          editableColumn("text", "text"),
+          editableColumn("number", "number"),
+          editableColumn("boolean", "boolean"),
+          editableColumn("date", "date"),
+          editableColumn("object", "object"),
+        ],
+      );
+      manager = new SelectionManager(pasteOptions);
+      manager.startSelection({ row: 0, col: 0 });
+
+      const result = manager.pasteClipboardText(
+        "hello\t42\ttrue\t2026-05-07\t{\"nested\":true}",
+      );
+
+      expect(result.changedCells).toHaveLength(5);
+      expect(pasteOptions.getData()[0]?.[0]).toBe("hello");
+      expect(pasteOptions.getData()[0]?.[1]).toBe(42);
+      expect(pasteOptions.getData()[0]?.[2]).toBe(true);
+      expect(pasteOptions.getData()[0]?.[3]).toBeInstanceOf(Date);
+      expect(pasteOptions.getData()[0]?.[4]).toEqual({ nested: true });
+    });
+
+    it("skips incompatible cells without aborting compatible cells", () => {
+      const pasteOptions = createPasteOptions(
+        [["initial", 10, false, { keep: true }]],
+        [
+          editableColumn("text", "text"),
+          editableColumn("number", "number"),
+          editableColumn("boolean", "boolean"),
+          editableColumn("object", "object"),
+        ],
+      );
+      manager = new SelectionManager(pasteOptions);
+      manager.startSelection({ row: 0, col: 0 });
+
+      const result = manager.pasteClipboardText("updated\tnope\tmaybe\tnot-json");
+
+      expect(result.handled).toBe(true);
+      expect(result.changedCells).toEqual([
+        { row: 0, col: 0, value: "updated" },
+      ]);
+      expect(pasteOptions.getData()[0]).toEqual([
+        "updated",
+        10,
+        false,
+        { keep: true },
+      ]);
+    });
+
+    it("skips non-editable and hidden target columns", () => {
+      const pasteOptions = createPasteOptions(
+        [[null, "locked", "hidden"]],
+        [
+          editableColumn("editable", "text"),
+          { field: "locked", cellDataType: "text", width: 100 },
+          editableColumn("hidden", "text", { hidden: true }),
+        ],
+      );
+      manager = new SelectionManager(pasteOptions);
+      manager.startSelection({ row: 0, col: 0 });
+
+      const result = manager.pasteClipboardText("A\tB\tC");
+
+      expect(result.changedCells).toEqual([{ row: 0, col: 0, value: "A" }]);
+      expect(pasteOptions.getData()[0]).toEqual(["A", "locked", "hidden"]);
+    });
+
+    it("clips pasted shapes at grid bounds", () => {
+      const pasteOptions = createPasteOptions(
+        [
+          [null, null],
+          [null, null],
+        ],
+        [
+          editableColumn("a", "text"),
+          editableColumn("b", "text"),
+        ],
+      );
+      manager = new SelectionManager(pasteOptions);
+      manager.startSelection({ row: 1, col: 1 });
+
+      const result = manager.pasteClipboardText("A\tB\nC\tD");
+
+      expect(result.changedCells).toEqual([{ row: 1, col: 1, value: "A" }]);
+      expect(pasteOptions.getData()).toEqual([
+        [null, null],
+        [null, "A"],
+      ]);
+    });
+
+    it("clips pasted shapes to the selected target range", () => {
+      const pasteOptions = createPasteOptions(
+        [
+          [null, null],
+          [null, null],
+          [null, null],
+          [null, null],
+        ],
+        [
+          editableColumn("a", "text"),
+          editableColumn("b", "text"),
+        ],
+      );
+      manager = new SelectionManager(pasteOptions);
+      manager.startSelection({ row: 1, col: 0 });
+      manager.startSelection({ row: 2, col: 0 }, { shift: true });
+
+      const result = manager.pasteClipboardText("A\nB\nC");
+
+      expect(result.changedCells).toEqual([
+        { row: 1, col: 0, value: "A" },
+        { row: 2, col: 0, value: "B" },
+      ]);
+      expect(pasteOptions.getData()).toEqual([
+        [null, null],
+        ["A", null],
+        ["B", null],
+        [null, null],
+      ]);
     });
   });
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -35,7 +35,7 @@ A high-performance, feature lean React data grid component built to manage grids
 - **Column Filtering**: Built-in filter row with debounced input
 - **Cell Editing**: Double-click or press Enter to edit, with custom editor support
 - **Fill Handle**: Excel-like drag-to-fill for editable cells
-- **Keyboard Navigation**: Arrow keys, Tab, Enter, Escape, Ctrl+A, Ctrl+C
+- **Keyboard Navigation**: Arrow keys, Tab, Enter, Escape, Ctrl+A, Ctrl+C, Ctrl+V
 - **Custom Renderers**: Registry-based cell, edit, and header renderers
 - **Dark Mode**: Built-in dark theme support
 - **TypeScript**: Full type safety with exported types
@@ -559,6 +559,7 @@ interface HeaderRendererParams {
 | Delete / Backspace | Start editing with empty value    |
 | Ctrl + A           | Select all                        |
 | Ctrl + C           | Copy selection to clipboard       |
+| Ctrl + V           | Paste clipboard values into selection |
 | Any character      | Start editing with that character |
 
 ## Styling

--- a/packages/react/src/Grid.tsx
+++ b/packages/react/src/Grid.tsx
@@ -197,6 +197,7 @@ export function Grid<TData = unknown>(
     handleHeaderMouseDown,
     handleHeaderResizeMouseDown,
     handleKeyDown,
+    handlePaste,
     handleWheel,
     dragState,
   } = useInputHandler(coreRef, containerRef, effectiveColumns, {
@@ -487,6 +488,7 @@ export function Grid<TData = unknown>(
         flexDirection: "column",
       }}
       onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
       tabIndex={0}
     >
       <GridHeader

--- a/packages/react/src/hooks/useInputHandler.ts
+++ b/packages/react/src/hooks/useInputHandler.ts
@@ -44,6 +44,7 @@ export interface UseInputHandlerResult {
   handleHeaderMouseDown: (colIndex: number, colWidth: number, colHeight: number, e: React.PointerEvent) => void;
   handleHeaderResizeMouseDown: (colIndex: number, colWidth: number, e: React.PointerEvent) => void;
   handleKeyDown: (e: React.KeyboardEvent) => void;
+  handlePaste: (e: React.ClipboardEvent) => void;
   handleWheel: (e: React.WheelEvent, wheelDampening: number) => void;
   // Drag state for UI rendering
   dragState: DragState;
@@ -467,6 +468,21 @@ export function useInputHandler<TData>(
     [coreRef, containerRef, activeCell, editingCell, filterPopupOpen, rowHeight, slots, rowsWrapperOffset]
   );
 
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const core = coreRef.current;
+      if (!core) return;
+      if (editingCell !== null) return;
+      if (filterPopupOpen) return;
+
+      const text = e.clipboardData.getData("text/plain");
+      if (core.pasteClipboardText(text)) {
+        e.preventDefault();
+      }
+    },
+    [coreRef, editingCell, filterPopupOpen]
+  );
+
   const handleWheel = useCallback(
     (e: React.WheelEvent, wheelDampening: number) => {
       const core = coreRef.current;
@@ -505,6 +521,7 @@ export function useInputHandler<TData>(
     handleHeaderMouseDown,
     handleHeaderResizeMouseDown,
     handleKeyDown,
+    handlePaste,
     handleWheel,
     dragState,
   };

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -89,7 +89,7 @@ export interface GridProps<TData = unknown> {
 
   /** Function to extract unique ID from row. Required when onCellValueChanged is provided. */
   getRowId?: (row: TData) => RowId;
-  /** Called when a cell value is changed via editing or fill drag. Requires getRowId. */
+  /** Called when a cell value is changed via editing, fill drag, or paste. Requires getRowId. */
   onCellValueChanged?: (event: CellValueChangedEvent<TData>) => void;
   /** Custom loading component to render instead of default spinner */
   loadingComponent?: React.ComponentType<{ isLoading: boolean }>;

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -35,7 +35,7 @@ A high-performance, feature lean Vue 3 data grid component built to manage grids
 - **Column Filtering**: Built-in filter row with debounced input
 - **Cell Editing**: Double-click or press Enter to edit, with custom editor support
 - **Fill Handle**: Excel-like drag-to-fill for editable cells
-- **Keyboard Navigation**: Arrow keys, Tab, Enter, Escape, Ctrl+A, Ctrl+C
+- **Keyboard Navigation**: Arrow keys, Tab, Enter, Escape, Ctrl+A, Ctrl+C, Ctrl+V
 - **Custom Renderers**: Registry-based cell, edit, and header renderers
 - **Dark Mode**: Built-in dark theme support
 - **TypeScript**: Full type safety with exported types
@@ -574,6 +574,7 @@ type VueHeaderRenderer = (
 | Delete / Backspace | Start editing with empty value    |
 | Ctrl + A           | Select all                        |
 | Ctrl + C           | Copy selection to clipboard       |
+| Ctrl + V           | Paste clipboard values into selection |
 | Any character      | Start editing with that character |
 
 ## Styling

--- a/packages/vue/src/GpGrid.vue
+++ b/packages/vue/src/GpGrid.vue
@@ -49,7 +49,7 @@ const props = withDefaults(
     highlighting?: HighlightingOptions<Row>;
     /** Function to extract unique ID from row. Required when onCellValueChanged is provided. */
     getRowId?: (row: Row) => RowId;
-    /** Called when a cell value is changed via editing or fill drag. Requires getRowId. */
+    /** Called when a cell value is changed via editing, fill drag, or paste. Requires getRowId. */
     onCellValueChanged?: (event: CellValueChangedEvent<Row>) => void;
     /** Custom loading component to render instead of default spinner */
     loadingComponent?: Component<{ isLoading: boolean }>;
@@ -127,6 +127,7 @@ const {
   handleHeaderMouseDown,
   handleHeaderResizeMouseDown,
   handleKeyDown,
+  handlePaste,
   handleWheel,
   dragState,
 } = useInputHandler(coreRef, bodyContainerRef, effectiveColumns, {
@@ -396,6 +397,7 @@ defineExpose({
     style="width: 100%; height: 100%; position: relative; display: flex; flex-direction: column"
     tabindex="0"
     @keydown="handleKeyDown"
+    @paste="handlePaste"
   >
     <GridHeader
       :header-height="totalHeaderHeight"

--- a/packages/vue/src/composables/useGpGrid.ts
+++ b/packages/vue/src/composables/useGpGrid.ts
@@ -46,7 +46,7 @@ export interface UseGpGridOptions<TData = unknown> {
   highlighting?: HighlightingOptions<TData>;
   /** Function to extract unique ID from row. Required when onCellValueChanged is provided. */
   getRowId?: (row: TData) => RowId;
-  /** Called when a cell value is changed via editing or fill drag. Requires getRowId. */
+  /** Called when a cell value is changed via editing, fill drag, or paste. Requires getRowId. */
   onCellValueChanged?: (event: CellValueChangedEvent<TData>) => void;
   cellRenderers?: Record<string, VueCellRenderer<TData>>;
   editRenderers?: Record<string, VueEditRenderer<TData>>;
@@ -79,6 +79,7 @@ export interface UseGpGridResult<TData = unknown> {
   handleFillHandleMouseDown: (e: PointerEvent) => void;
   handleHeaderClick: (colIndex: number, e: MouseEvent) => void;
   handleKeyDown: (e: KeyboardEvent) => void;
+  handlePaste: (e: ClipboardEvent) => void;
   handleWheel: (e: WheelEvent, wheelDampening: number) => void;
   handleFilterApply: (colId: string, filter: ColumnFilterModel | null) => void;
   handleFilterPopupClose: () => void;
@@ -142,6 +143,7 @@ export function useGpGrid<TData = unknown>(
     handleFillHandleMouseDown,
     handleHeaderClick,
     handleKeyDown,
+    handlePaste,
     handleWheel,
     dragState,
   } = useInputHandler<TData>(
@@ -341,6 +343,7 @@ export function useGpGrid<TData = unknown>(
     handleFillHandleMouseDown,
     handleHeaderClick,
     handleKeyDown,
+    handlePaste,
     handleWheel,
     handleFilterApply,
     handleFilterPopupClose,

--- a/packages/vue/src/composables/useInputHandler.ts
+++ b/packages/vue/src/composables/useInputHandler.ts
@@ -51,6 +51,7 @@ export interface UseInputHandlerResult {
   handleHeaderMouseDown: (colIndex: number, colWidth: number, colHeight: number, e: PointerEvent) => void;
   handleHeaderResizeMouseDown: (colIndex: number, colWidth: number, e: PointerEvent) => void;
   handleKeyDown: (e: KeyboardEvent) => void;
+  handlePaste: (e: ClipboardEvent) => void;
   handleWheel: (e: WheelEvent, wheelDampening: number) => void;
   dragState: Ref<DragState>;
 }
@@ -469,6 +470,18 @@ export function useInputHandler<TData = unknown>(
     }
   }
 
+  function handlePaste(e: ClipboardEvent): void {
+    const core = coreRef.value;
+    if (core === null) return;
+    if (editingCell.value !== null) return;
+    if (filterPopupOpen.value) return;
+
+    const text = e.clipboardData?.getData("text/plain") ?? "";
+    if (core.pasteClipboardText(text)) {
+      e.preventDefault();
+    }
+  }
+
   function handleWheel(e: WheelEvent, wheelDampening: number): void {
     const core = coreRef.value;
     const container = containerRef.value;
@@ -504,6 +517,7 @@ export function useInputHandler<TData = unknown>(
     handleHeaderMouseDown,
     handleHeaderResizeMouseDown,
     handleKeyDown,
+    handlePaste,
     handleWheel,
     dragState,
   };

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -84,7 +84,7 @@ export interface GpGridProps<TData = unknown> {
   headerRenderer?: VueHeaderRenderer;
   /** Function to extract unique ID from row. Required when onCellValueChanged is provided. */
   getRowId?: (row: TData) => RowId;
-  /** Called when a cell value is changed via editing or fill drag. Requires getRowId. */
+  /** Called when a cell value is changed via editing, fill drag, or paste. Requires getRowId. */
   onCellValueChanged?: (event: CellValueChangedEvent<TData>) => void;
   /** Custom loading component to render instead of default spinner */
   loadingComponent?: Component<{ isLoading: boolean }>;

--- a/playgrounds/vite-vue/src/App.vue
+++ b/playgrounds/vite-vue/src/App.vue
@@ -73,7 +73,7 @@ const columns: ColumnDefinition[] = [
         headerName: "ID",
         cellRenderer: Bold,
     },
-    { field: "name", cellDataType: "text", width: 150, headerName: "Name" },
+    { field: "name", editable: true, cellDataType: "text", width: 150, headerName: "Name" },
     {
         field: "age",
         cellDataType: "text",


### PR DESCRIPTION
Now when copying a set of cells (rows, columns, matrixes), gp-grid preserves the copy layout within the target selected range (it gets clamped). This allow to copy paste easily within the grid.